### PR TITLE
fix: adapt angular helper to merge repeated keys

### DIFF
--- a/src/lib/server/renderers/angular/angular.helper.ts
+++ b/src/lib/server/renderers/angular/angular.helper.ts
@@ -5,27 +5,28 @@ import lodash from 'lodash';
 export function getLanguageLiteralsJson(language: LanguageInterface, data: RawDataType[]) {
 	const i18n: { [index: string]: object | string } = {};
 
-	data.forEach(row => {
-		lodash.merge(i18n, _transformToObject(row, language))
+	data.forEach((row) => {
+		lodash.mergeWith(i18n, _transformToObject(row, language), customMerge);
+		//lodash.merge(i18n, _transformToObject(row, language));
 	});
 
 	return i18n;
 }
 
 function _transformToObject(row: RawDataType, language: LanguageInterface) {
-	const keyList = (`${ Object.values(row)[0] }`).split('_');
-	return {..._getKeyValue(keyList, row, language)};
+	const keyList = `${Object.values(row)[0]}`.split('_');
+	return { ..._getKeyValue(keyList, row, language) };
 }
 
 function _getKeyValue(data: string[], row: RawDataType, language: LanguageInterface) {
-	const keyValue: { [index: string] : object | string } = {};
+	const keyValue: { [index: string]: object | string } = {};
 	const key = _getNormalizedKey(data[0]);
 
 	if (data.length === 1) {
 		keyValue[key] = replaceAndEscapeValues(row[language.name] ?? '');
 	} else {
 		const aux = _getNextKeyList(data);
-		keyValue[key] = {..._getKeyValue(aux, row, language)};
+		keyValue[key] = { ..._getKeyValue(aux, row, language) };
 	}
 
 	return keyValue;
@@ -36,7 +37,32 @@ function _getNextKeyList(key: string[]) {
 }
 
 function _getNormalizedKey(key: string) {
-	return key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`).toUpperCase();
+	return key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`).toUpperCase();
+}
+
+function customMerge(objValue: string | object, srcValue: string | object, key: string) {
+	// Si ambos son objetos, deja que _.merge actúe normalmente
+	if (lodash.isPlainObject(objValue) && lodash.isPlainObject(srcValue)) {
+		return undefined;
+	}
+
+	// Si el valor existente es string y el nuevo también es string -> deja que _.merge actúe normalmente
+	if (lodash.isString(objValue) && lodash.isString(srcValue)) {
+		return undefined;
+	}
+
+	// Si el valor existente es string y el nuevo es objeto
+	if (lodash.isString(objValue) && lodash.isPlainObject(srcValue)) {
+		return lodash.merge({ [key]: objValue }, srcValue);
+	}
+
+	// Si el valor existente es objeto y el nuevo es string
+	if (lodash.isPlainObject(objValue) && lodash.isString(srcValue)) {
+		return lodash.merge(objValue, { [key]: srcValue });
+	}
+
+	// Para otros tipos, sobrescribe normalmente
+	return undefined;
 }
 
 export function reformatDynamicValues(literal: string) {
@@ -55,5 +81,6 @@ export function replaceAndEscapeValues(literal: string) {
 			.replace(/([’´`])/g, "'")
 			.replace(/([“”])/g, '\\"')
 			.replaceAll('\u00A0', ' ')
+			.replace(/\\n/g, '\n')
 	);
 }


### PR DESCRIPTION
When there are a simple key like common_remove e.g. and a complex or object type key like common_remove_description, the last one replaces the first one. 

It has been modified so it will be merging them instead of replacing them. 
common_remove
common_remove_description 

Will be

"COMMON": {
       "COMMON": 'asd',
       "DESCRIPTION: 'asd2'
}